### PR TITLE
Added additional derivable traits

### DIFF
--- a/libosdp/src/channel.rs
+++ b/libosdp/src/channel.rs
@@ -19,7 +19,7 @@
 use core::ffi::c_void;
 
 /// OSDP channel errors
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ChannelError {
     /// Channel is temporarily unavailable (could have blocked until it was
     /// ready but LibOSDP required channel to be non-blocking so return "I would

--- a/libosdp/src/commands.rs
+++ b/libosdp/src/commands.rs
@@ -546,7 +546,7 @@ impl From<OsdpCommand> for libosdp_sys::osdp_cmd {
             OsdpCommand::Buzzer(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_BUZZER,
                 __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    buzzer: c.clone().into(),
+                    buzzer: c.into(),
                 },
             },
             OsdpCommand::Text(c) => libosdp_sys::osdp_cmd {
@@ -558,13 +558,13 @@ impl From<OsdpCommand> for libosdp_sys::osdp_cmd {
             OsdpCommand::Output(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_OUTPUT,
                 __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    output: c.clone().into(),
+                    output: c.into(),
                 },
             },
             OsdpCommand::ComSet(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_COMSET,
                 __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    comset: c.clone().into(),
+                    comset: c.into(),
                 },
             },
             OsdpCommand::KeySet(c) => libosdp_sys::osdp_cmd {
@@ -582,13 +582,13 @@ impl From<OsdpCommand> for libosdp_sys::osdp_cmd {
             OsdpCommand::FileTx(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_FILE_TX,
                 __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    file_tx: c.clone().into(),
+                    file_tx: c.into(),
                 },
             },
             OsdpCommand::Status(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_STATUS,
                 __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    status: c.clone().into(),
+                    status: c.into(),
                 },
             },
         }

--- a/libosdp/src/commands.rs
+++ b/libosdp/src/commands.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use super::ConvertEndian;
 
 /// LED Colors as specified in OSDP for the on_color/off_color parameters.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum OsdpLedColor {
     /// No Color
     #[default]
@@ -68,7 +68,7 @@ impl From<OsdpLedColor> for u8 {
 }
 
 /// LED params sub-structure. Part of LED command: OsdpCommandLed
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpLedParams {
     /// Control code serves different purposes based on which member of
     /// [`OsdpCommandLed`] it is used with. They are,
@@ -128,7 +128,7 @@ impl From<OsdpLedParams> for libosdp_sys::osdp_cmd_led_params {
 }
 
 /// Command to control the behavior of it's on-board LEDs
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpCommandLed {
     /// Reader (another device connected to this PD) for which this command is
     /// issued for.
@@ -174,7 +174,7 @@ impl From<OsdpCommandLed> for libosdp_sys::osdp_cmd_led {
 }
 
 /// Command to control the behavior of a buzzer in the PD
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpCommandBuzzer {
     /// Reader (another device connected to this PD) for which this command is
     /// issued for.
@@ -230,7 +230,7 @@ impl From<OsdpCommandBuzzer> for libosdp_sys::osdp_cmd_buzzer {
 
 /// Command to manipulate the on-board display unit (Can be LED, LCD, 7-Segment,
 /// etc.,) on the PD.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpCommandText {
     /// Reader (another device connected to this PD) for which this command is
     /// issued for.
@@ -294,7 +294,7 @@ impl From<OsdpCommandText> for libosdp_sys::osdp_cmd_text {
 }
 
 /// Command to control digital output exposed by the PD.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpCommandOutput {
     /// The output number this to apply this action.
     ///
@@ -341,7 +341,7 @@ impl From<OsdpCommandOutput> for libosdp_sys::osdp_cmd_output {
 /// Command to set the communication parameters for the PD. The effects of this
 /// command is expected to be be stored in PD's non-volatile memory as the CP
 /// will expect the PD to be in this state moving forward.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpComSet {
     address: u8,
     baud_rate: u32,
@@ -379,7 +379,7 @@ impl From<OsdpComSet> for libosdp_sys::osdp_cmd_comset {
 }
 
 /// Command to set secure channel keys to the PD.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpCommandKeyset {
     key_type: u8,
     /// Key data
@@ -422,7 +422,7 @@ impl From<OsdpCommandKeyset> for libosdp_sys::osdp_cmd_keyset {
 }
 
 /// Command to to act as a wrapper for manufacturer specific commands
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpCommandMfg {
     /// 3-byte IEEE assigned OUI used as vendor code
     pub vendor_code: (u8, u8, u8),
@@ -462,7 +462,7 @@ impl From<OsdpCommandMfg> for libosdp_sys::osdp_cmd_mfg {
 }
 
 /// Command to kick-off a file transfer to the PD.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpCommandFileTx {
     id: i32,
     flags: u32,
@@ -501,7 +501,7 @@ impl From<OsdpCommandFileTx> for libosdp_sys::osdp_cmd_file_tx {
 
 /// CP interacts with and controls PDs by sending commands to it. The commands
 /// in this enum are specified by OSDP specification.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum OsdpCommand {
     /// Command to control the behavior of it’s on-board LEDs
     Led(OsdpCommandLed),

--- a/libosdp/src/events.rs
+++ b/libosdp/src/events.rs
@@ -146,7 +146,7 @@ impl From<OsdpEventCardRead> for libosdp_sys::osdp_event_cardread {
         data[..value.data.len()].copy_from_slice(&value.data[..]);
         libosdp_sys::osdp_event_cardread {
             reader_no: value.reader_no,
-            format: value.format.clone().into(),
+            format: value.format.into(),
             direction: value.direction as i32,
             length,
             data,
@@ -389,7 +389,7 @@ impl From<OsdpEvent> for libosdp_sys::osdp_event {
             OsdpEvent::Status(e) => libosdp_sys::osdp_event {
                 type_: libosdp_sys::osdp_event_type_OSDP_EVENT_STATUS,
                 __bindgen_anon_1: libosdp_sys::osdp_event__bindgen_ty_1 {
-                    status: e.clone().into(),
+                    status: e.into(),
                 },
             },
         }

--- a/libosdp/src/events.rs
+++ b/libosdp/src/events.rs
@@ -17,7 +17,7 @@ type Result<T> = core::result::Result<T, OsdpError>;
 
 /// Various card formats that a PD can support. This is sent to CP when a PD
 /// must report a card read
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum OsdpCardFormats {
     /// Card format is not specified
     Unspecified,
@@ -60,7 +60,7 @@ impl From<OsdpCardFormats> for libosdp_sys::osdp_event_cardread_format_e {
 }
 
 /// Event that describes card read activity on the PD
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpEventCardRead {
     /// Reader (another device connected to this PD) which caused this event
     ///
@@ -200,7 +200,7 @@ impl From<OsdpEventKeyPress> for libosdp_sys::osdp_event_keypress {
 }
 
 /// Event to transport a Manufacturer specific command's response.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpEventMfgReply {
     /// 3-byte IEEE assigned OUI used as vendor code
     pub vendor_code: (u8, u8, u8),
@@ -239,8 +239,8 @@ impl From<OsdpEventMfgReply> for libosdp_sys::osdp_event_mfgrep {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 /// Status report type
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum OsdpStatusReportType {
     /// Input status report
     Input,
@@ -299,7 +299,7 @@ impl From<OsdpStatusReportType> for libosdp_sys::osdp_status_report_type {
 /// number of items as described in the corresponding capability codes,
 /// - PdCapability::OutputControl
 /// - PdCapability::ContactStatusMonitoring
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct OsdpStatusReport {
     type_: OsdpStatusReportType,
     nr_entries: usize,

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -95,7 +95,7 @@ pub use cp::ControlPanel;
 pub use pd::PeripheralDevice;
 
 /// OSDP public errors
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "std", derive(Error))]
 pub enum OsdpError {
     /// PD info error

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -95,7 +95,7 @@ pub use cp::ControlPanel;
 pub use pd::PeripheralDevice;
 
 /// OSDP public errors
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "std", derive(Error))]
 pub enum OsdpError {
     /// PD info error

--- a/libosdp/src/pdcap.rs
+++ b/libosdp/src/pdcap.rs
@@ -8,7 +8,7 @@ use core::str::FromStr;
 use crate::OsdpError;
 
 /// PD capability entity to be used inside [`PdCapability`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct PdCapEntity {
     compliance: u8,
     num_items: u8,
@@ -68,7 +68,7 @@ impl FromStr for PdCapEntity {
 
 /// OSDP defined PD capabilities. PDs expose/advertise features they support to
 /// the CP by means of "capabilities".
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum PdCapability {
     /// This function indicates the ability to monitor the status of a switch
     /// using a two-wire electrical connection between the PD and the switch.

--- a/libosdp/src/pdid.rs
+++ b/libosdp/src/pdid.rs
@@ -6,7 +6,7 @@
 use super::ConvertEndian;
 
 /// PD ID information advertised by the PD.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct PdId {
     /// 1-Byte Manufacturer's version number
     pub version: i32,

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -82,7 +82,7 @@ impl PdInfoBuilder {
     /// received a `CMD_ID`. For CP mode, this field is ignored, but PD mode
     /// must set
     pub fn id(mut self, id: &PdId) -> PdInfoBuilder {
-        self.id = id.clone();
+        self.id = *id;
         self
     }
 
@@ -147,7 +147,7 @@ impl PdInfo {
             baud_rate: self.baud_rate,
             address: self.address,
             flags: self.flags.bits() as i32,
-            id: self.id.clone().into(),
+            id: self.id.into(),
             cap: self.cap.as_ptr(),
             channel: self.channel.take().unwrap().into(),
             scbk,

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -8,7 +8,7 @@ use alloc::ffi::CString;
 use crate::{Channel, OsdpError, OsdpFlag, PdCapability, PdId};
 
 /// OSDP PD Information. This struct is used to describe a PD to LibOSDP
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PdInfo {
     name: CString,
     address: i32,

--- a/libosdp/tests/file_transfer.rs
+++ b/libosdp/tests/file_transfer.rs
@@ -28,7 +28,7 @@ use std::os::unix::prelude::FileExt;
 use std::os::windows::fs::FileExt;
 
 /// OSDP file transfer context
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OsdpFileManager {
     files: HashMap<i32, PathBuf>,
     file: Option<File>,

--- a/libosdp/tests/file_transfer.rs
+++ b/libosdp/tests/file_transfer.rs
@@ -36,10 +36,7 @@ pub struct OsdpFileManager {
 
 impl OsdpFileManager {
     pub fn new() -> Self {
-        Self {
-            files: HashMap::new(),
-            file: None,
-        }
+        Self::default()
     }
 
     pub fn register_file(&mut self, id: i32, path: &str) {

--- a/osdpctl/src/config.rs
+++ b/osdpctl/src/config.rs
@@ -24,6 +24,7 @@ fn vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {
         .unwrap_or_else(|v: Vec<T>| panic!("Expected a Vec of length {} but it was {}", N, v.len()))
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct KeyStore {
     store: PathBuf,
 }
@@ -82,6 +83,7 @@ impl KeyStore {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PdData {
     pub name: String,
     channel: String,
@@ -90,6 +92,7 @@ pub struct PdData {
     flags: OsdpFlag,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CpConfig {
     pub runtime_dir: PathBuf,
     pub name: String,
@@ -158,6 +161,7 @@ impl CpConfig {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PdConfig {
     pub runtime_dir: PathBuf,
     pub name: String,
@@ -255,6 +259,8 @@ impl PdConfig {
     }
 }
 
+/// Configuration for the
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum DeviceConfig {
     CpConfig(CpConfig),
     PdConfig(PdConfig),

--- a/osdpctl/src/config.rs
+++ b/osdpctl/src/config.rs
@@ -259,7 +259,6 @@ impl PdConfig {
     }
 }
 
-/// Configuration for the
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum DeviceConfig {
     CpConfig(CpConfig),


### PR DESCRIPTION
While working with the library, I noticed that a few of the traits that could exist don't.
While I don't have a concrete usecase for most of them, some would be handy.

For example, `PdCapability` implementing `Eq` is pretty handy.. ^^

For others, like `OsdpFileManager::new()`, deriving `Default` is a bit simpler..