### PR TITLE
added getter-methods to `PdInfo`

### DIFF
--- a/libosdp/src/commands.rs
+++ b/libosdp/src/commands.rs
@@ -545,9 +545,7 @@ impl From<OsdpCommand> for libosdp_sys::osdp_cmd {
             },
             OsdpCommand::Buzzer(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_BUZZER,
-                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    buzzer: c.into(),
-                },
+                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 { buzzer: c.into() },
             },
             OsdpCommand::Text(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_TEXT,
@@ -557,15 +555,11 @@ impl From<OsdpCommand> for libosdp_sys::osdp_cmd {
             },
             OsdpCommand::Output(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_OUTPUT,
-                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    output: c.into(),
-                },
+                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 { output: c.into() },
             },
             OsdpCommand::ComSet(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_COMSET,
-                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    comset: c.into(),
-                },
+                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 { comset: c.into() },
             },
             OsdpCommand::KeySet(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_KEYSET,
@@ -581,15 +575,11 @@ impl From<OsdpCommand> for libosdp_sys::osdp_cmd {
             },
             OsdpCommand::FileTx(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_FILE_TX,
-                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    file_tx: c.into(),
-                },
+                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 { file_tx: c.into() },
             },
             OsdpCommand::Status(c) => libosdp_sys::osdp_cmd {
                 id: libosdp_sys::osdp_cmd_e_OSDP_CMD_STATUS,
-                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 {
-                    status: c.into(),
-                },
+                __bindgen_anon_1: libosdp_sys::osdp_cmd__bindgen_ty_1 { status: c.into() },
             },
         }
     }

--- a/libosdp/src/events.rs
+++ b/libosdp/src/events.rs
@@ -388,9 +388,7 @@ impl From<OsdpEvent> for libosdp_sys::osdp_event {
             },
             OsdpEvent::Status(e) => libosdp_sys::osdp_event {
                 type_: libosdp_sys::osdp_event_type_OSDP_EVENT_STATUS,
-                __bindgen_anon_1: libosdp_sys::osdp_event__bindgen_ty_1 {
-                    status: e.into(),
-                },
+                __bindgen_anon_1: libosdp_sys::osdp_event__bindgen_ty_1 { status: e.into() },
             },
         }
     }

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -19,6 +19,119 @@ pub struct PdInfo {
     channel: Option<Box<dyn Channel>>,
     scbk: Option<[u8; 16]>,
 }
+impl PdInfo {
+    /// Gets the PDs `name`
+    /// A user provided `name` for this PD (log messages include this name defaults to `pd-<address>`)
+    ///
+    /// # Example
+    /// ```
+    /// # use libosdp::PdInfoBuilder;
+    /// let pd = PdInfoBuilder::new().name("door_42").unwrap().build();
+    /// assert_eq!(pd.name(), "door_42".to_string());
+    /// ```
+    #[must_use]
+    pub fn name(&self) -> String {
+        self.name
+            .clone()
+            .into_string()
+            .expect("since this is configured with a &str, this must be valid String")
+    }
+    /// Gets the PDs 7 bit `address`
+    /// The special address 0x7F is used for broadcast.
+    /// So there can be 2^7-1 valid addresses on a bus.
+    ///
+    /// # Example
+    /// ```
+    /// # use libosdp::PdInfoBuilder;
+    /// let pd = PdInfoBuilder::new().address(42).unwrap().build();
+    /// assert_eq!(pd.address(), 42);
+    /// ```
+    #[must_use]
+    pub fn address(&self) -> i32 {
+        self.address
+    }
+
+    /// Gets the PDs baud rate.
+    /// Can be one of `9600`/`19200`/`38400`/`57600`/`115200`/`230400`
+    ///
+    /// # Example
+    /// ```
+    /// # use libosdp::PdInfoBuilder;
+    /// let pd = PdInfoBuilder::new().baud_rate(9600).unwrap().build();
+    /// assert_eq!(pd.baud_rate(), 9600);
+    /// ```
+    pub fn baud_rate(&self) -> i32 {
+        self.baud_rate
+    }
+
+    /// Gets the PDs [`OsdpFlag`]
+    /// Used to modify the way the context is set up
+    ///
+    /// # Example
+    /// ```
+    /// # use libosdp::{OsdpFlag, PdInfoBuilder};
+    /// let pd = PdInfoBuilder::new().flag(OsdpFlag::EnforceSecure).build();
+    /// assert_eq!(pd.flag(), OsdpFlag::EnforceSecure);
+    /// ```
+    #[must_use]
+    pub fn flag(&self) -> OsdpFlag {
+        self.flags
+    }
+
+    /// Gets the PDs' [`PdId`]
+    /// Static information that the PD reports to the CP when it received a `CMD_ID`.
+    /// For CP mode, this field is ignored, but PD mode must set it
+    ///
+    /// # Example
+    /// ```
+    /// # use libosdp::{PdId, PdInfoBuilder};
+    /// let pd = PdInfoBuilder::new().id(&PdId::from_number(42)).build();
+    /// assert_eq!(pd.id(), PdId::from_number(42));
+    /// ```
+    #[must_use]
+    pub fn id(&self) -> PdId {
+        self.id
+    }
+
+    /// Get a PDs [`PdCapability`]s
+    ///
+    /// # Example
+    /// ```
+    /// # use libosdp::{PdCapability, PdInfoBuilder, PdCapEntity};
+    /// let pd = PdInfoBuilder::new()
+    ///             .capability(PdCapability::CommunicationSecurity(PdCapEntity::new(1, 1)))
+    ///             .capability(PdCapability::AudibleOutput(PdCapEntity::new(1, 1)))
+    ///             .build();
+    /// assert_eq!(
+    ///   pd.capabilities(),
+    ///   vec![PdCapability::CommunicationSecurity(PdCapEntity::new(1, 1)), PdCapability::AudibleOutput(PdCapEntity::new(1, 1))]
+    /// );
+    /// ```
+    #[must_use]
+    pub fn capabilities(&self) -> Vec<PdCapability> {
+        self.cap.iter().cloned().map(PdCapability::from).collect()
+    }
+
+    /// Get a PDs secure channel key.
+    /// If the key is not set, the PD will be set to install mode.
+    ///
+    /// # Example
+    /// ```
+    /// # use libosdp::PdInfoBuilder;
+    /// # #[rustfmt::skip]
+    /// # let pd_0_key = [
+    /// #   0x94, 0x4b, 0x8e, 0xdd, 0xcb, 0xaa, 0x2b, 0x5f,
+    /// #   0xe2, 0xb0, 0x14, 0x8d, 0x1b, 0x2f, 0x95, 0xc9
+    /// # ];
+    /// let pd = PdInfoBuilder::new().secure_channel_key(pd_0_key).build();
+    /// assert_eq!(pd.secure_channel_key(), Some(pd_0_key));
+    /// ```
+
+    #[must_use]
+    pub fn secure_channel_key(&self) -> Option<[u8; 16]> {
+        self.scbk
+    }
+}
 
 /// OSDP PD Info Builder
 #[derive(Debug, Default)]
@@ -57,7 +170,7 @@ impl PdInfoBuilder {
         Ok(self)
     }
 
-    /// Set baud rate; can be one of 9600/19200/38400/57600/115200/230400
+    /// Set baud rate; can be one of `9600`/`19200`/`38400`/`57600`/`115200`/`230400`
     pub fn baud_rate(mut self, baud_rate: i32) -> Result<PdInfoBuilder, OsdpError> {
         if baud_rate != 9600
             && baud_rate != 19200
@@ -80,7 +193,7 @@ impl PdInfoBuilder {
 
     /// Set PD ID; Static information that the PD reports to the CP when it
     /// received a `CMD_ID`. For CP mode, this field is ignored, but PD mode
-    /// must set
+    /// must set it
     pub fn id(mut self, id: &PdId) -> PdInfoBuilder {
         self.id = *id;
         self
@@ -94,7 +207,8 @@ impl PdInfoBuilder {
 
     /// Set multiple capabilities at once
     pub fn capabilities<'a, I>(mut self, caps: I) -> PdInfoBuilder
-        where I: IntoIterator<Item=&'a PdCapability>,
+    where
+        I: IntoIterator<Item = &'a PdCapability>,
     {
         for cap in caps {
             self.cap.push(cap.clone().into());
@@ -108,7 +222,7 @@ impl PdInfoBuilder {
         self
     }
 
-    /// Set secure channel key. If the key is not set, the PD will be be set to
+    /// Set secure channel key. If the key is not set, the PD will be set to
     /// install mode.
     pub fn secure_channel_key(mut self, key: [u8; 16]) -> PdInfoBuilder {
         self.scbk = Some(key);


### PR DESCRIPTION
Currently, all fields of `PdInfo` are private.
The current way, to get access to them is to `as_struct` an instance and then compare the c-fields. This is somewhat cumbersome to do and not quite ergonomic.

=> I think making these fields is likely better

If you'd like that more, I can make these fields into methods 
An alternative would be to just publish parts of the fields, but that is something that I would want your oppinion on ^^