### PR TITLE
Added `obi1kenobi/cargo-semver-checks` to the publishing workflows

### DIFF
--- a/.github/workflows/publish-libosdp-sys.yml
+++ b/.github/workflows/publish-libosdp-sys.yml
@@ -43,6 +43,10 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+      with:
+        package: libosdp-sys
     - name: "Publish crate"
       run: |
         cargo publish --token ${CRATES_TOKEN} -p libosdp-sys

--- a/.github/workflows/publish-libosdp.yml
+++ b/.github/workflows/publish-libosdp.yml
@@ -43,6 +43,10 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+      with:
+        package: libosdp
     - name: "Publish crate"
       run: |
         cargo publish --token ${CRATES_TOKEN} -p libosdp

--- a/.github/workflows/publish-osdpctl.yml
+++ b/.github/workflows/publish-osdpctl.yml
@@ -35,6 +35,10 @@ jobs:
       run: echo "TAG=${REL_TAG}" >> "${GITHUB_ENV}"
       env:
         REL_TAG: ${{ github.ref_name }}
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+      with:
+        package: osdpctl
     - name: "Publish crate"
       run: |
         cargo publish --token ${CRATES_TOKEN} -p osdpctl


### PR DESCRIPTION
`cargo-semver-checks` is quite usefull and spots changes which seem inoquius, but are breaking.
While this is an external tool, it is quite a well-known and trusted one, as can be seen that it is on rusts [2024H2-Roadmap](https://rust-lang.github.io/rust-project-goals/2024h2/cargo-semver-checks.html).