### PR TITLE
Changed from `actions-rs` to more maintained alternatives

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -21,14 +21,11 @@ jobs:
         with:
           submodules: recursive
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check
   test:
     runs-on: ubuntu-latest
     steps:
@@ -37,10 +34,8 @@ jobs:
         with:
           submodules: recursive
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           toolchain: stable
       - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test

--- a/.github/workflows/publish-libosdp-sys.yml
+++ b/.github/workflows/publish-libosdp-sys.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
       with:
         toolchain: stable
         override: true
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
       with:
         toolchain: stable
         override: true

--- a/.github/workflows/publish-libosdp.yml
+++ b/.github/workflows/publish-libosdp.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
       with:
         toolchain: stable
         override: true
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
       with:
         toolchain: stable
         override: true

--- a/.github/workflows/publish-osdpctl.yml
+++ b/.github/workflows/publish-osdpctl.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
       with:
         toolchain: stable
         override: true

--- a/libosdp/tests/common/device.rs
+++ b/libosdp/tests/common/device.rs
@@ -16,6 +16,7 @@ type Result<T> = core::result::Result<T, libosdp::OsdpError>;
 
 pub struct CpDevice {
     dev: Arc<Mutex<ControlPanel>>,
+    #[allow(unused)] // false positive, it is used!
     pub receiver: Receiver<(i32, OsdpEvent)>,
 }
 

--- a/libosdp/tests/common/threadbus.rs
+++ b/libosdp/tests/common/threadbus.rs
@@ -20,6 +20,7 @@ pub struct ThreadBus {
     recv: Mutex<BroadcastReceiver<Vec<u8>>>,
 }
 
+#[allow(unused)] // false positive, it is used!
 fn str_to_channel_id(key: &str) -> i32 {
     let mut hasher = DefaultHasher::new();
     key.hash(&mut hasher);
@@ -29,6 +30,7 @@ fn str_to_channel_id(key: &str) -> i32 {
 }
 
 impl ThreadBus {
+    #[allow(unused)] // false positive, it is used!
     pub fn new(name: &str) -> Self {
         let (send, recv) = multiqueue::broadcast_queue(4);
         Self {


### PR DESCRIPTION
'This resolves these, which I noticed during #10's [actions run](https://github.com/goToMain/libosdp-rs/actions/runs/10443470570?pr=10):

![image](https://github.com/user-attachments/assets/2e530682-c40d-4f5e-9ac8-2ec53115e68c)

There are a ton of options avaliable, maybe even a `rust-lang`-action https://github.com/rust-lang/rustup/issues/3409

> [!NOTE]
> This is not without downside as replacing `uses: actions-rs/cargo` with `run: cargo ...` does not come with the annotations that github displays f. ex. here:
> ![image](https://github.com/user-attachments/assets/6b61c970-800d-4489-8433-bd5df44bc5fa)
> Said annotation would still be shown, but only as a test failour and not inline..
