### PR TITLE
Make libosdp-sys no_std compatible

### DIFF
--- a/libosdp-sys/Cargo.toml
+++ b/libosdp-sys/Cargo.toml
@@ -14,11 +14,13 @@ categories = ["development-tools", "embedded"]
 
 [build-dependencies]
 anyhow = "1.0.75"
-bindgen = "0.69.1"
+bindgen = "0.70.0"
 build-target = "0.4.0"
 cc = "1.0.83"
 
 [features]
+default = ["std"]
+std = []
 packet_trace = []
 data_trace = []
 skip_mark_byte = []

--- a/libosdp-sys/build.rs
+++ b/libosdp-sys/build.rs
@@ -166,10 +166,9 @@ fn main() -> Result<()> {
 
     /* generate bindings */
 
-    let args = vec![
-        format!("-I{}", &out_dir),
-    ];
+    let args = vec![format!("-I{}", &out_dir)];
     let bindings = bindgen::Builder::default()
+        .use_core()
         .header("vendor/include/osdp.h")
         .clang_args(args)
         .generate()

--- a/libosdp-sys/src/lib.rs
+++ b/libosdp-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 //! Auto generated (bindgen) wrapper for LibOSDP C API exposed from osdp.h
 //! [here](https://github.com/goToMain/libosdp/blob/master/include/osdp.h).
 


### PR DESCRIPTION
`libosdp-sys` could not be built in a `no_std` environment before. Now it can with `default-features = false`.