### PR TITLE
Make libosdp no_std compatible

### DIFF
--- a/libosdp-sys/Cargo.toml
+++ b/libosdp-sys/Cargo.toml
@@ -19,8 +19,6 @@ build-target = "0.4.0"
 cc = "1.0.83"
 
 [features]
-default = ["std"]
-std = []
 packet_trace = []
 data_trace = []
 skip_mark_byte = []

--- a/libosdp-sys/src/lib.rs
+++ b/libosdp-sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 //! Auto generated (bindgen) wrapper for LibOSDP C API exposed from osdp.h
 //! [here](https://github.com/goToMain/libosdp/blob/master/include/osdp.h).
 

--- a/libosdp/Cargo.toml
+++ b/libosdp/Cargo.toml
@@ -14,10 +14,11 @@ categories = ["development-tools", "embedded"]
 
 [dependencies]
 bitflags = "2.4.0"
-libosdp-sys = "3.0.6"
+embedded-io = { version = "0.6.1", features = ["alloc"] }
+libosdp-sys = { path = "../libosdp-sys", default-features = false }
 log = "0.4.20"
-once_cell = "1.18.0"
-serde = { version = "1.0.192", features = ["derive"] }
+once_cell = { version = "1.18.0", optional = true, default-features = false, features = ["alloc", "critical-section"] }
+serde = { version = "1.0.192", features = ["derive", "alloc"], default-features = false }
 thiserror = { version = "1.0.50", optional = true }
 
 [dev-dependencies]
@@ -29,7 +30,8 @@ sha256 = "1.5.0"
 
 [features]
 default = ["std"]
-std = ["thiserror"]
+arc = ["once_cell"]
+std = ["libosdp-sys/std", "thiserror", "serde/std", "once_cell/std", "arc"]
 
 [[example]]
 name = "cp"

--- a/libosdp/Cargo.toml
+++ b/libosdp/Cargo.toml
@@ -29,7 +29,7 @@ sha256 = "1.5.0"
 
 [features]
 default = ["std"]
-std = ["libosdp-sys/std", "thiserror", "serde/std"]
+std = ["thiserror", "serde/std"]
 
 [[example]]
 name = "cp"

--- a/libosdp/Cargo.toml
+++ b/libosdp/Cargo.toml
@@ -17,7 +17,6 @@ bitflags = "2.4.0"
 embedded-io = { version = "0.6.1", features = ["alloc"] }
 libosdp-sys = { path = "../libosdp-sys", default-features = false }
 log = "0.4.20"
-once_cell = { version = "1.18.0", optional = true, default-features = false, features = ["alloc", "critical-section"] }
 serde = { version = "1.0.192", features = ["derive", "alloc"], default-features = false }
 thiserror = { version = "1.0.50", optional = true }
 
@@ -30,8 +29,7 @@ sha256 = "1.5.0"
 
 [features]
 default = ["std"]
-arc = ["once_cell"]
-std = ["libosdp-sys/std", "thiserror", "serde/std", "once_cell/std", "arc"]
+std = ["libosdp-sys/std", "thiserror", "serde/std"]
 
 [[example]]
 name = "cp"

--- a/libosdp/src/channel.rs
+++ b/libosdp/src/channel.rs
@@ -44,8 +44,6 @@ impl From<std::io::Error> for ChannelError {
 impl<E: embedded_io::Error + Sized> From<E> for ChannelError {
     fn from(value: E) -> Self {
         match value.kind() {
-            //TODO determine if this is the correct error kind
-            // embedded_io::ErrorKind::TimedOut => ChannelError::WouldBlock,
             _ => ChannelError::TransportError,
         }
     }

--- a/libosdp/src/channel.rs
+++ b/libosdp/src/channel.rs
@@ -16,7 +16,7 @@
 //! This module provides a way to define an OSDP channel and export it to
 //! LibOSDP.
 
-use crate::{vec, Box};
+use alloc::{boxed::Box, vec};
 use core::ffi::c_void;
 
 /// OSDP channel errors

--- a/libosdp/src/channel.rs
+++ b/libosdp/src/channel.rs
@@ -16,6 +16,7 @@
 //! This module provides a way to define an OSDP channel and export it to
 //! LibOSDP.
 
+use crate::{vec, Box};
 use core::ffi::c_void;
 
 /// OSDP channel errors
@@ -29,10 +30,22 @@ pub enum ChannelError {
     TransportError,
 }
 
+#[cfg(feature = "std")]
 impl From<std::io::Error> for ChannelError {
     fn from(value: std::io::Error) -> Self {
         match value.kind() {
             std::io::ErrorKind::WouldBlock => ChannelError::WouldBlock,
+            _ => ChannelError::TransportError,
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<E: embedded_io::Error + Sized> From<E> for ChannelError {
+    fn from(value: E) -> Self {
+        match value.kind() {
+            //TODO determine if this is the correct error kind
+            // embedded_io::ErrorKind::TimedOut => ChannelError::WouldBlock,
             _ => ChannelError::TransportError,
         }
     }

--- a/libosdp/src/commands.rs
+++ b/libosdp/src/commands.rs
@@ -7,7 +7,8 @@
 //! are specified by OSDP specification. This module is responsible to handling
 //! such commands though [`OsdpCommand`].
 
-use crate::{OsdpStatusReport, Vec};
+use crate::OsdpStatusReport;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 use super::ConvertEndian;

--- a/libosdp/src/commands.rs
+++ b/libosdp/src/commands.rs
@@ -7,7 +7,7 @@
 //! are specified by OSDP specification. This module is responsible to handling
 //! such commands though [`OsdpCommand`].
 
-use crate::OsdpStatusReport;
+use crate::{OsdpStatusReport, Vec};
 use serde::{Deserialize, Serialize};
 
 use super::ConvertEndian;

--- a/libosdp/src/cp.rs
+++ b/libosdp/src/cp.rs
@@ -7,9 +7,9 @@
 //! (PD) on the OSDP bus. It can send commands to and receive events from PDs.
 
 use crate::{
-    file::OsdpFileOps, Box, OsdpCommand, OsdpError, OsdpEvent, OsdpFlag, PdCapability, PdId,
-    PdInfo, Vec,
+    file::OsdpFileOps, OsdpCommand, OsdpError, OsdpEvent, OsdpFlag, PdCapability, PdId, PdInfo,
 };
+use alloc::{boxed::Box, vec::Vec};
 use core::ffi::c_void;
 use log::{debug, error, info, warn};
 

--- a/libosdp/src/cp.rs
+++ b/libosdp/src/cp.rs
@@ -6,9 +6,9 @@
 //! The Control Panel (CP) is responsible to connecting to and managing multiple Peripheral Devices
 //! (PD) on the OSDP bus. It can send commands to and receive events from PDs.
 
-#[cfg(feature = "std")]
 use crate::{
-    file::OsdpFileOps, OsdpCommand, OsdpError, OsdpEvent, OsdpFlag, PdCapability, PdId, PdInfo,
+    file::OsdpFileOps, Box, OsdpCommand, OsdpError, OsdpEvent, OsdpFlag, PdCapability, PdId,
+    PdInfo, Vec,
 };
 use core::ffi::c_void;
 use log::{debug, error, info, warn};

--- a/libosdp/src/events.rs
+++ b/libosdp/src/events.rs
@@ -8,7 +8,8 @@
 //! etc.,). They do this by creating an "event" and sending it to the CP. This
 //! module is responsible to handling such events though [`OsdpEvent`].
 
-use crate::{OsdpError, Vec};
+use crate::OsdpError;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 use super::ConvertEndian;

--- a/libosdp/src/events.rs
+++ b/libosdp/src/events.rs
@@ -8,7 +8,7 @@
 //! etc.,). They do this by creating an "event" and sending it to the CP. This
 //! module is responsible to handling such events though [`OsdpEvent`].
 
-use crate::OsdpError;
+use crate::{OsdpError, Vec};
 use serde::{Deserialize, Serialize};
 
 use super::ConvertEndian;

--- a/libosdp/src/file.rs
+++ b/libosdp/src/file.rs
@@ -6,7 +6,7 @@
 //! OSDP provides a means to send files from CP to a Peripheral Device (PD).
 //! This module adds the required components to achieve this effect.
 
-use crate::{vec, Box};
+use alloc::{boxed::Box, vec};
 use core::ffi::c_void;
 
 type Result<T> = core::result::Result<T, crate::OsdpError>;

--- a/libosdp/src/file.rs
+++ b/libosdp/src/file.rs
@@ -6,6 +6,7 @@
 //! OSDP provides a means to send files from CP to a Peripheral Device (PD).
 //! This module adds the required components to achieve this effect.
 
+use crate::{vec, Box};
 use core::ffi::c_void;
 
 type Result<T> = core::result::Result<T, crate::OsdpError>;
@@ -57,7 +58,7 @@ unsafe extern "C" fn file_read(data: *mut c_void, buf: *mut c_void, size: i32, o
             -1
         }
     };
-    std::ptr::copy_nonoverlapping(read_buf.as_mut_ptr(), buf as *mut u8, len as usize);
+    core::ptr::copy_nonoverlapping(read_buf.as_mut_ptr(), buf as *mut u8, len as usize);
     len
 }
 
@@ -70,7 +71,7 @@ unsafe extern "C" fn file_write(
     let ctx: *mut Box<dyn OsdpFileOps> = data as *mut _;
     let ctx = ctx.as_ref().unwrap();
     let mut write_buf = vec![0u8; size as usize];
-    std::ptr::copy_nonoverlapping(buf as *mut u8, write_buf.as_mut_ptr(), size as usize);
+    core::ptr::copy_nonoverlapping(buf as *mut u8, write_buf.as_mut_ptr(), size as usize);
     match ctx.offset_write(&write_buf, offset as u64) {
         Ok(len) => len as i32,
         Err(e) => {

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -83,9 +83,8 @@ pub use pdid::*;
 pub use pdinfo::*;
 
 #[allow(unused_imports)]
-use alloc::{
-    borrow::ToOwned, boxed::Box, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec,
-};
+use alloc::{borrow::ToOwned, boxed::Box, format, string::String};
+
 #[cfg(feature = "std")]
 use thiserror::Error;
 
@@ -196,7 +195,7 @@ bitflags::bitflags! {
     }
 }
 
-impl FromStr for OsdpFlag {
+impl core::str::FromStr for OsdpFlag {
     type Err = OsdpError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -82,14 +82,10 @@ pub use pdcap::*;
 pub use pdid::*;
 pub use pdinfo::*;
 
-#[cfg(feature = "arc")]
-use alloc::sync::Arc;
 #[allow(unused_imports)]
 use alloc::{
     borrow::ToOwned, boxed::Box, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec,
 };
-#[cfg(feature = "arc")]
-use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
 use thiserror::Error;
 
@@ -218,26 +214,16 @@ fn cstr_to_string(s: *const ::core::ffi::c_char) -> String {
     s.to_str().unwrap().to_owned()
 }
 
-#[cfg(feature = "arc")]
-static VERSION: Lazy<Arc<String>> = Lazy::new(|| {
-    let s = unsafe { libosdp_sys::osdp_get_version() };
-    Arc::new(cstr_to_string(s))
-});
-
-#[cfg(feature = "arc")]
-static SOURCE_INFO: Lazy<Arc<String>> = Lazy::new(|| {
-    let s = unsafe { libosdp_sys::osdp_get_source_info() };
-    Arc::new(cstr_to_string(s))
-});
-
 /// Get LibOSDP version
-#[cfg(feature = "arc")]
-pub fn get_version() -> String {
-    VERSION.as_ref().clone()
+pub fn get_version() -> &'static str {
+    let s = unsafe { libosdp_sys::osdp_get_version() };
+    let s = unsafe { core::ffi::CStr::from_ptr(s) };
+    s.to_str().unwrap()
 }
 
 /// Get LibOSDP source info string
-#[cfg(feature = "arc")]
-pub fn get_source_info() -> String {
-    SOURCE_INFO.as_ref().clone()
+pub fn get_source_info() -> &'static str {
+    let s = unsafe { libosdp_sys::osdp_get_source_info() };
+    let s = unsafe { core::ffi::CStr::from_ptr(s) };
+    s.to_str().unwrap()
 }

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -82,11 +82,13 @@ pub use pdcap::*;
 pub use pdid::*;
 pub use pdinfo::*;
 
+#[cfg(feature = "arc")]
+use alloc::sync::Arc;
 #[allow(unused_imports)]
 use alloc::{
-    borrow::ToOwned, boxed::Box, ffi::CString, format, str::FromStr, string::String, sync::Arc,
-    vec, vec::Vec,
+    borrow::ToOwned, boxed::Box, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec,
 };
+#[cfg(feature = "arc")]
 use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
 use thiserror::Error;
@@ -216,22 +218,26 @@ fn cstr_to_string(s: *const ::core::ffi::c_char) -> String {
     s.to_str().unwrap().to_owned()
 }
 
+#[cfg(feature = "arc")]
 static VERSION: Lazy<Arc<String>> = Lazy::new(|| {
     let s = unsafe { libosdp_sys::osdp_get_version() };
     Arc::new(cstr_to_string(s))
 });
 
+#[cfg(feature = "arc")]
 static SOURCE_INFO: Lazy<Arc<String>> = Lazy::new(|| {
     let s = unsafe { libosdp_sys::osdp_get_source_info() };
     Arc::new(cstr_to_string(s))
 });
 
 /// Get LibOSDP version
+#[cfg(feature = "arc")]
 pub fn get_version() -> String {
     VERSION.as_ref().clone()
 }
 
 /// Get LibOSDP source info string
+#[cfg(feature = "arc")]
 pub fn get_source_info() -> String {
     SOURCE_INFO.as_ref().clone()
 }

--- a/libosdp/src/pd.rs
+++ b/libosdp/src/pd.rs
@@ -12,7 +12,8 @@
 //! happens on the PD itself (such as card read, key press, etc.,) snd sends it
 //! to the CP.
 
-use crate::{Box, OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo, Vec};
+use crate::{OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo};
+use alloc::{boxed::Box, vec::Vec};
 use core::ffi::c_void;
 use log::{debug, error, info, warn};
 

--- a/libosdp/src/pd.rs
+++ b/libosdp/src/pd.rs
@@ -12,7 +12,7 @@
 //! happens on the PD itself (such as card read, key press, etc.,) snd sends it
 //! to the CP.
 
-use crate::{OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo};
+use crate::{Box, OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo, Vec};
 use core::ffi::c_void;
 use log::{debug, error, info, warn};
 

--- a/libosdp/src/pdcap.rs
+++ b/libosdp/src/pdcap.rs
@@ -5,7 +5,7 @@
 
 use core::str::FromStr;
 
-use crate::OsdpError;
+use crate::{format, OsdpError};
 
 /// PD capability entity to be used inside [`PdCapability`]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]

--- a/libosdp/src/pdcap.rs
+++ b/libosdp/src/pdcap.rs
@@ -3,9 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::format;
 use core::str::FromStr;
 
-use crate::{format, OsdpError};
+use crate::OsdpError;
 
 /// PD capability entity to be used inside [`PdCapability`]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -5,7 +5,7 @@
 
 use alloc::ffi::CString;
 
-use crate::{Channel, OsdpError, OsdpFlag, PdCapability, PdId};
+use crate::{format, Box, Channel, OsdpError, OsdpFlag, PdCapability, PdId, String, Vec};
 
 /// OSDP PD Information. This struct is used to describe a PD to LibOSDP
 #[derive(Debug, Default)]
@@ -254,7 +254,7 @@ impl PdInfo {
         if let Some(key) = self.scbk.as_mut() {
             scbk = key.as_mut_ptr();
         } else {
-            scbk = std::ptr::null_mut::<u8>();
+            scbk = core::ptr::null_mut::<u8>();
         }
         libosdp_sys::osdp_pd_info_t {
             name: self.name.as_ptr(),

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -3,9 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use alloc::ffi::CString;
+use alloc::{boxed::Box, ffi::CString, format, string::String, vec::Vec};
 
-use crate::{format, Box, Channel, OsdpError, OsdpFlag, PdCapability, PdId, String, Vec};
+use crate::{Channel, OsdpError, OsdpFlag, PdCapability, PdId};
 
 /// OSDP PD Information. This struct is used to describe a PD to LibOSDP
 #[derive(Debug, Default)]


### PR DESCRIPTION
Depends on #16.

The feature `arc` is introduced, because some targets like `thumbv6m-none-eabi` don't support CAS operations and therefore don't support `Arc`. By disabling this feature these targets can be supported, too. I will probably looking into implementing `get_version()` and `get_source_info()` some other way that does not rely on CAS operations, but this way `libosdp` can at least be built for those targets now.