### PR TITLE
Fix unsoundness in PdInfo::as_struct()

### DIFF
--- a/libosdp/src/cp.rs
+++ b/libosdp/src/cp.rs
@@ -57,6 +57,9 @@ where
 
 fn cp_setup(info: Vec<libosdp_sys::osdp_pd_info_t>) -> Result<*mut c_void> {
     let ctx = unsafe { libosdp_sys::osdp_cp_setup(info.len() as i32, info.as_ptr()) };
+    for pd in info.into_iter() {
+        crate::drop_osdp_pd_info(pd);
+    }
     if ctx.is_null() {
         Err(OsdpError::Setup)
     } else {

--- a/libosdp/src/cp.rs
+++ b/libosdp/src/cp.rs
@@ -55,11 +55,8 @@ where
     trampoline::<F>
 }
 
-fn cp_setup(info: Vec<libosdp_sys::osdp_pd_info_t>) -> Result<*mut c_void> {
-    let ctx = unsafe { libosdp_sys::osdp_cp_setup(info.len() as i32, info.as_ptr()) };
-    for pd in info.into_iter() {
-        crate::drop_osdp_pd_info(pd);
-    }
+fn cp_setup(info: Vec<crate::OsdpPdInfoHandle>) -> Result<*mut c_void> {
+    let ctx = unsafe { libosdp_sys::osdp_cp_setup(info.len() as i32, info.as_ptr() as *const _) };
     if ctx.is_null() {
         Err(OsdpError::Setup)
     } else {
@@ -77,12 +74,11 @@ unsafe impl Send for ControlPanel {}
 
 impl ControlPanel {
     /// Create a new CP context for the list of PDs described by the [`PdInfo`] vector.
-    pub fn new(mut pd_info: Vec<PdInfo>) -> Result<Self> {
+    pub fn new(pd_info: Vec<PdInfo>) -> Result<Self> {
         if pd_info.len() > 126 {
             return Err(OsdpError::PdInfo("max PD count exceeded"));
         }
-        let info: Vec<libosdp_sys::osdp_pd_info_t> =
-            pd_info.iter_mut().map(|i| i.as_struct()).collect();
+        let info: Vec<crate::OsdpPdInfoHandle> = pd_info.into_iter().map(|i| i.into()).collect();
         unsafe { libosdp_sys::osdp_set_log_callback(Some(log_handler)) };
         Ok(Self {
             ctx: cp_setup(info)?,

--- a/libosdp/src/pd.rs
+++ b/libosdp/src/pd.rs
@@ -57,10 +57,9 @@ where
     trampoline::<F>
 }
 
-fn pd_setup(mut info: PdInfo) -> Result<*mut c_void> {
-    let info_struct = info.as_struct();
-    let ctx = unsafe { libosdp_sys::osdp_pd_setup(&info_struct) };
-    crate::drop_osdp_pd_info(info_struct);
+fn pd_setup(info: PdInfo) -> Result<*mut c_void> {
+    let info: crate::OsdpPdInfoHandle = info.into();
+    let ctx = unsafe { libosdp_sys::osdp_pd_setup(&*info) };
     if ctx.is_null() {
         Err(OsdpError::Setup)
     } else {

--- a/libosdp/src/pd.rs
+++ b/libosdp/src/pd.rs
@@ -58,7 +58,9 @@ where
 }
 
 fn pd_setup(mut info: PdInfo) -> Result<*mut c_void> {
-    let ctx = unsafe { libosdp_sys::osdp_pd_setup(&info.as_struct()) };
+    let info_struct = info.as_struct();
+    let ctx = unsafe { libosdp_sys::osdp_pd_setup(&info_struct) };
+    crate::drop_osdp_pd_info(info_struct);
     if ctx.is_null() {
         Err(OsdpError::Setup)
     } else {

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -5,7 +5,7 @@
 
 use alloc::ffi::CString;
 
-use crate::{Channel, OsdpError, OsdpFlag, PdCapability, PdId};
+use crate::{Box, Channel, OsdpError, OsdpFlag, PdCapability, PdId};
 
 /// OSDP PD Information. This struct is used to describe a PD to LibOSDP
 #[derive(Debug, Default)]
@@ -253,18 +253,27 @@ impl PdInfo {
         let scbk = if let Some(key) = self.scbk {
             Box::into_raw(Box::new(key)) as *mut _
         } else {
-            std::ptr::null_mut::<u8>()
+            core::ptr::null_mut::<u8>()
         };
-        let mut cap = self.cap.clone();
-        let cap_ptr = cap.as_mut_ptr();
-        core::mem::forget(cap);
+        let cap = if !self.cap.is_empty() {
+            let mut cap = self.cap.clone();
+            cap.reserve(1);
+            cap.push(libosdp_sys::osdp_pd_cap {
+                function_code: -1i8 as u8,
+                compliance_level: 0,
+                num_items: 0,
+            });
+            Box::into_raw(cap.into_boxed_slice()) as *mut _
+        } else {
+            core::ptr::null_mut::<libosdp_sys::osdp_pd_cap>()
+        };
         libosdp_sys::osdp_pd_info_t {
             name: self.name.clone().into_raw(),
             baud_rate: self.baud_rate,
             address: self.address,
             flags: self.flags.bits() as i32,
             id: self.id.into(),
-            cap: cap_ptr,
+            cap: cap as *mut _,
             channel: self.channel.take().unwrap().into(),
             scbk,
         }

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use core::ops::Deref;
+
 use alloc::ffi::CString;
 
 use crate::{Box, Channel, OsdpError, OsdpFlag, PdCapability, PdId};
@@ -247,16 +249,26 @@ impl PdInfoBuilder {
     }
 }
 
-impl PdInfo {
-    /// Get a C-repr struct for PdInfo that LibOSDP can operate on.
-    pub fn as_struct(&mut self) -> libosdp_sys::osdp_pd_info_t {
-        let scbk = if let Some(key) = self.scbk {
+#[repr(transparent)]
+pub(crate) struct OsdpPdInfoHandle(pub libosdp_sys::osdp_pd_info_t);
+
+impl Deref for OsdpPdInfoHandle {
+    type Target = libosdp_sys::osdp_pd_info_t;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<PdInfo> for OsdpPdInfoHandle {
+    fn from(info: PdInfo) -> OsdpPdInfoHandle {
+        let scbk = if let Some(key) = info.scbk {
             Box::into_raw(Box::new(key)) as *mut _
         } else {
             core::ptr::null_mut::<u8>()
         };
-        let cap = if !self.cap.is_empty() {
-            let mut cap = self.cap.clone();
+        let cap = if !info.cap.is_empty() {
+            let mut cap = info.cap.clone();
             cap.reserve(1);
             cap.push(libosdp_sys::osdp_pd_cap {
                 function_code: -1i8 as u8,
@@ -267,39 +279,42 @@ impl PdInfo {
         } else {
             core::ptr::null_mut::<libosdp_sys::osdp_pd_cap>()
         };
-        libosdp_sys::osdp_pd_info_t {
-            name: self.name.clone().into_raw(),
-            baud_rate: self.baud_rate,
-            address: self.address,
-            flags: self.flags.bits() as i32,
-            id: self.id.into(),
+        OsdpPdInfoHandle(libosdp_sys::osdp_pd_info_t {
+            name: info.name.clone().into_raw(),
+            baud_rate: info.baud_rate,
+            address: info.address,
+            flags: info.flags.bits() as i32,
+            id: info.id.into(),
             cap: cap as *mut _,
-            channel: self.channel.take().unwrap().into(),
+            channel: info.channel.unwrap().into(),
             scbk,
-        }
+        })
     }
 }
 
-pub(crate) fn drop_osdp_pd_info(info: libosdp_sys::osdp_pd_info_t) {
-    unsafe {
-        // The name is not copied by LibOSDP, so we cannot drop it here
-        // if !info.name.is_null() {
-        //     drop(CString::from_raw(info.name as *mut _));
-        // }
-        if !info.cap.is_null() {
-            let mut cap = info.cap as *mut libosdp_sys::osdp_pd_cap;
-            while (*cap).function_code != -1i8 as u8 {
-                cap = cap.add(1);
+impl Drop for OsdpPdInfoHandle {
+    fn drop(&mut self) {
+        unsafe {
+            let info = self.0;
+            // LibOSDP versions <= 3.0.6 do not copy the name, so this is only valid for >= 3.0.7
+            if !info.name.is_null() {
+                drop(CString::from_raw(info.name as *mut _));
             }
-            let len = (cap.offset_from(info.cap) + 1) as usize;
-            drop(Vec::from_raw_parts(
-                info.cap as *mut libosdp_sys::osdp_pd_cap,
-                len,
-                len,
-            ));
-        }
-        if !info.scbk.is_null() {
-            drop(Box::from_raw(info.scbk as *mut [u8; 16]));
+            if !info.cap.is_null() {
+                let mut cap = info.cap as *mut libosdp_sys::osdp_pd_cap;
+                while (*cap).function_code != -1i8 as u8 {
+                    cap = cap.add(1);
+                }
+                let len = (cap.offset_from(info.cap) + 1) as usize;
+                drop(Vec::from_raw_parts(
+                    info.cap as *mut libosdp_sys::osdp_pd_cap,
+                    len,
+                    len,
+                ));
+            }
+            if !info.scbk.is_null() {
+                drop(Box::from_raw(info.scbk as *mut [u8; 16]));
+            }
         }
     }
 }

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -279,3 +279,27 @@ impl PdInfo {
         }
     }
 }
+
+pub(crate) fn drop_osdp_pd_info(info: libosdp_sys::osdp_pd_info_t) {
+    unsafe {
+        // The name is not copied by LibOSDP, so we cannot drop it here
+        // if !info.name.is_null() {
+        //     drop(CString::from_raw(info.name as *mut _));
+        // }
+        if !info.cap.is_null() {
+            let mut cap = info.cap as *mut libosdp_sys::osdp_pd_cap;
+            while (*cap).function_code != -1i8 as u8 {
+                cap = cap.add(1);
+            }
+            let len = (cap.offset_from(info.cap) + 1) as usize;
+            drop(Vec::from_raw_parts(
+                info.cap as *mut libosdp_sys::osdp_pd_cap,
+                len,
+                len,
+            ));
+        }
+        if !info.scbk.is_null() {
+            drop(Box::from_raw(info.scbk as *mut [u8; 16]));
+        }
+    }
+}


### PR DESCRIPTION
Since `PdInfo.scbk`'s lifetime is bound to `PdInfo`, `osdp_pd_info_t` may outlive it. Currently it would still hold a reference to `PdInfo`'s `scbk` which would be unsound.
This fixes this by effectively cloning `scbk` so that it has a `'static` lifetime.

Another option would be to change `PdInfoBuilder::secure_channel_key` to accept a `&'static [u8;16]` instead. This would get rid of the unsoundness too and would not require a heap allocation per PD. This would change the API and might make it slightly more difficult to use, but may be worth it.

What do you think?

Edit:
I just realized that (almost) the same goes for the `name` and `cap` fields. And I am pretty sure that `cap` needs to be either `NULL` or end with a `(-1, 0, 0)` sentinel so I changed that, too.