### PR TITLE
Allow for Channels to be easily shared between PDs

### DIFF
--- a/libosdp/examples/cp.rs
+++ b/libosdp/examples/cp.rs
@@ -57,10 +57,10 @@ fn main() -> Result<(), OsdpError> {
         .address(101)?
         .baud_rate(115200)?
         .flag(OsdpFlag::EnforceSecure)
-        .channel(Box::new(channel))
-        .secure_channel_key(pd_0_key)
-        .build();
-    let mut cp = libosdp::ControlPanel::new(vec![pd_0])?;
+        .secure_channel_key(pd_0_key);
+    let mut cp = libosdp::ControlPanelBuilder::new()
+        .add_channel(Box::new(channel), vec![pd_0])
+        .build()?;
     loop {
         cp.refresh();
         thread::sleep(Duration::from_millis(50));

--- a/libosdp/examples/pd.rs
+++ b/libosdp/examples/pd.rs
@@ -60,10 +60,8 @@ fn main() -> Result<(), OsdpError> {
         .baud_rate(115200)?
         .flag(OsdpFlag::EnforceSecure)
         .capability(PdCapability::CommunicationSecurity(PdCapEntity::new(1, 1)))
-        .channel(Box::new(channel))
-        .secure_channel_key(key)
-        .build();
-    let mut pd = libosdp::PeripheralDevice::new(pd_info)?;
+        .secure_channel_key(key);
+    let mut pd = libosdp::PeripheralDevice::new(pd_info, Box::new(channel))?;
     pd.set_command_callback(|_| {
         println!("Received command!");
         0

--- a/libosdp/src/channel.rs
+++ b/libosdp/src/channel.rs
@@ -51,7 +51,7 @@ impl<E: embedded_io::Error + Sized> From<E> for ChannelError {
 
 /// The Channel trait acts as an interface for all channel implementors. See
 /// module description for the definition of a "channel" in LibOSDP.
-pub trait Channel: Send + Sync {
+pub trait Channel: Send {
     /// Since OSDP channels can be multi-drop (more than one PD can talk to a
     /// CP on the same channel) and LibOSDP supports mixing multi-drop
     /// connections among PDs it needs a way to identify each unique channel by

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -88,7 +88,7 @@ use alloc::{borrow::ToOwned, boxed::Box, format, string::String};
 #[cfg(feature = "std")]
 use thiserror::Error;
 
-pub use cp::ControlPanel;
+pub use cp::{ControlPanel, ControlPanelBuilder};
 pub use pd::PeripheralDevice;
 
 /// OSDP public errors

--- a/libosdp/src/pd.rs
+++ b/libosdp/src/pd.rs
@@ -12,8 +12,10 @@
 //! happens on the PD itself (such as card read, key press, etc.,) snd sends it
 //! to the CP.
 
-use crate::{OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo};
-use alloc::{boxed::Box, vec::Vec};
+use crate::{
+    Box, Channel, OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo,
+    PdInfoBuilder,
+};
 use core::ffi::c_void;
 use log::{debug, error, info, warn};
 
@@ -77,10 +79,10 @@ pub struct PeripheralDevice {
 unsafe impl Send for PeripheralDevice {}
 
 impl PeripheralDevice {
-    /// Create a new Peripheral panel object for the list of PDs described by the
-    /// corresponding PdInfo struct.
-    pub fn new(info: PdInfo) -> Result<Self> {
+    /// Create a new Peripheral panel object for the PD described by the corresponding PdInfo struct.
+    pub fn new(info: PdInfoBuilder, channel: Box<dyn Channel>) -> Result<Self> {
         unsafe { libosdp_sys::osdp_set_log_callback(Some(log_handler)) };
+        let info = info.channel(channel.into()).build();
         Ok(Self {
             ctx: pd_setup(info)?,
         })

--- a/libosdp/src/pdinfo.rs
+++ b/libosdp/src/pdinfo.rs
@@ -3,9 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use core::ops::Deref;
+use crate::{OsdpError, OsdpFlag, PdCapability, PdId};
 use alloc::{boxed::Box, ffi::CString, format, string::String, vec::Vec};
-use crate::{Channel, OsdpError, OsdpFlag, PdCapability, PdId};
+use core::ops::Deref;
 
 /// OSDP PD Information. This struct is used to describe a PD to LibOSDP
 #[derive(Debug, Default)]
@@ -16,7 +16,7 @@ pub struct PdInfo {
     flags: OsdpFlag,
     id: PdId,
     cap: Vec<libosdp_sys::osdp_pd_cap>,
-    channel: Option<Box<dyn Channel>>,
+    channel: Option<libosdp_sys::osdp_channel>,
     scbk: Option<[u8; 16]>,
 }
 impl PdInfo {
@@ -142,7 +142,7 @@ pub struct PdInfoBuilder {
     flags: OsdpFlag,
     id: PdId,
     cap: Vec<libosdp_sys::osdp_pd_cap>,
-    channel: Option<Box<dyn Channel>>,
+    channel: Option<libosdp_sys::osdp_channel>,
     scbk: Option<[u8; 16]>,
 }
 
@@ -217,7 +217,7 @@ impl PdInfoBuilder {
     }
 
     /// Set Osdp communication channel
-    pub fn channel(mut self, channel: Box<dyn Channel>) -> PdInfoBuilder {
+    pub fn channel(mut self, channel: libosdp_sys::osdp_channel) -> PdInfoBuilder {
         self.channel = Some(channel);
         self
     }
@@ -284,7 +284,7 @@ impl From<PdInfo> for OsdpPdInfoHandle {
             flags: info.flags.bits() as i32,
             id: info.id.into(),
             cap: cap as *mut _,
-            channel: info.channel.unwrap().into(),
+            channel: info.channel.expect("no channel provided"),
             scbk,
         })
     }

--- a/osdpctl/src/cp.rs
+++ b/osdpctl/src/cp.rs
@@ -7,7 +7,7 @@ use std::{thread, time::Duration};
 
 use crate::config::CpConfig;
 use anyhow::Context;
-use libosdp::{ControlPanel, OsdpEvent};
+use libosdp::OsdpEvent;
 use std::io::Write;
 
 type Result<T> = anyhow::Result<T, anyhow::Error>;
@@ -29,8 +29,8 @@ fn setup(dev: &CpConfig, daemonize: bool) -> Result<()> {
 
 pub fn main(dev: CpConfig, daemonize: bool) -> Result<()> {
     setup(&dev, daemonize)?;
-    let pd_info = dev.pd_info().context("Failed to create PD info list")?;
-    let mut cp = ControlPanel::new(pd_info)?;
+    let cp = dev.pd_info().context("Failed to create PD info list")?;
+    let mut cp = cp.build()?;
     cp.set_event_callback(|pd, event| {
         match event {
             OsdpEvent::CardRead(e) => {

--- a/osdpctl/src/pd.rs
+++ b/osdpctl/src/pd.rs
@@ -29,8 +29,8 @@ fn setup(dev: &PdConfig, daemonize: bool) -> Result<()> {
 
 pub fn main(dev: PdConfig, daemonize: bool) -> Result<()> {
     setup(&dev, daemonize)?;
-    let pd_info = dev.pd_info().context("Failed to create PD info")?;
-    let mut pd = PeripheralDevice::new(pd_info)?;
+    let (channel, pd_info) = dev.pd_info().context("Failed to create PD info")?;
+    let mut pd = PeripheralDevice::new(pd_info, channel)?;
     pd.set_command_callback(|command| {
         match command {
             OsdpCommand::Led(c) => {


### PR DESCRIPTION
This fixes #15. Currently dependent on #16 and #17.

With this change users of `libosdp-rs` don't need a `Channel` per PD anymore and can instead share a channel.