### PR TITLE
defmt support

### DIFF
--- a/libosdp/Cargo.toml
+++ b/libosdp/Cargo.toml
@@ -19,6 +19,7 @@ libosdp-sys = { path = "../libosdp-sys", default-features = false }
 log = "0.4.20"
 serde = { version = "1.0.192", features = ["derive", "alloc"], default-features = false }
 thiserror = { version = "1.0.50", optional = true }
+defmt = { version = "0.3", optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 env_logger = "0.11.3"
@@ -29,7 +30,8 @@ sha256 = "1.5.0"
 
 [features]
 default = ["std"]
-std = ["thiserror", "serde/std"]
+defmt-03 = ["embedded-io/defmt-03", "dep:defmt"]
+std = ["thiserror", "serde/std", "log/std"]
 
 [[example]]
 name = "cp"

--- a/libosdp/src/cp.rs
+++ b/libosdp/src/cp.rs
@@ -11,6 +11,9 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use core::ffi::c_void;
+#[cfg(feature = "defmt-03")]
+use defmt::{debug, error, info, warn};
+#[cfg(not(feature = "defmt-03"))]
 use log::{debug, error, info, warn};
 
 type Result<T> = core::result::Result<T, OsdpError>;
@@ -24,14 +27,14 @@ unsafe extern "C" fn log_handler(
     let msg = crate::cstr_to_string(msg);
     let msg = msg.trim();
     match log_level as libosdp_sys::osdp_log_level_e {
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_EMERG => error!("CP: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_ALERT => error!("CP: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_CRIT => error!("CP: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_ERROR => error!("CP: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_WARNING => warn!("CP: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_NOTICE => warn!("CP: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_INFO => info!("CP: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_DEBUG => debug!("CP: {msg}"),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_EMERG => error!("CP: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_ALERT => error!("CP: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_CRIT => error!("CP: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_ERROR => error!("CP: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_WARNING => warn!("CP: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_NOTICE => warn!("CP: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_INFO => info!("CP: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_DEBUG => debug!("CP: {}", msg),
         _ => panic!("Unknown log level"),
     };
 }

--- a/libosdp/src/events.rs
+++ b/libosdp/src/events.rs
@@ -16,9 +16,13 @@ use super::ConvertEndian;
 
 type Result<T> = core::result::Result<T, OsdpError>;
 
+#[cfg(feature = "defmt-03")]
+use defmt::panic;
+
 /// Various card formats that a PD can support. This is sent to CP when a PD
 /// must report a card read
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum OsdpCardFormats {
     /// Card format is not specified
     Unspecified,
@@ -62,6 +66,7 @@ impl From<OsdpCardFormats> for libosdp_sys::osdp_event_cardread_format_e {
 
 /// Event that describes card read activity on the PD
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct OsdpEventCardRead {
     /// Reader (another device connected to this PD) which caused this event
     ///
@@ -157,6 +162,7 @@ impl From<OsdpEventCardRead> for libosdp_sys::osdp_event_cardread {
 
 /// Event to describe a key press activity on the PD
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct OsdpEventKeyPress {
     /// Reader (another device connected to this PD) which caused this event
     ///
@@ -202,6 +208,7 @@ impl From<OsdpEventKeyPress> for libosdp_sys::osdp_event_keypress {
 
 /// Event to transport a Manufacturer specific command's response.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct OsdpEventMfgReply {
     /// 3-byte IEEE assigned OUI used as vendor code
     pub vendor_code: (u8, u8, u8),
@@ -242,6 +249,7 @@ impl From<OsdpEventMfgReply> for libosdp_sys::osdp_event_mfgrep {
 
 /// Status report type
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum OsdpStatusReportType {
     /// Input status report
     Input,
@@ -301,6 +309,7 @@ impl From<OsdpStatusReportType> for libosdp_sys::osdp_status_report_type {
 /// - PdCapability::OutputControl
 /// - PdCapability::ContactStatusMonitoring
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct OsdpStatusReport {
     type_: OsdpStatusReportType,
     nr_entries: usize,
@@ -352,6 +361,7 @@ impl From<OsdpStatusReport> for libosdp_sys::osdp_status_report {
 /// it to the CP. This module is responsible to handling such events though
 /// OsdpEvent.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum OsdpEvent {
     /// Event that describes card read activity on the PD
     CardRead(OsdpEventCardRead),

--- a/libosdp/src/file.rs
+++ b/libosdp/src/file.rs
@@ -8,6 +8,10 @@
 
 use alloc::{boxed::Box, vec};
 use core::ffi::c_void;
+#[cfg(feature = "defmt-03")]
+use defmt::error;
+#[cfg(not(feature = "defmt-03"))]
+use log::error;
 
 type Result<T> = core::result::Result<T, crate::OsdpError>;
 
@@ -41,7 +45,7 @@ unsafe extern "C" fn file_open(data: *mut c_void, file_id: i32, size: *mut i32) 
             0
         }
         Err(e) => {
-            log::error!("open: {:?}", e);
+            error!("open: {:?}", e);
             -1
         }
     }
@@ -54,7 +58,7 @@ unsafe extern "C" fn file_read(data: *mut c_void, buf: *mut c_void, size: i32, o
     let len = match ctx.offset_read(&mut read_buf, offset as u64) {
         Ok(len) => len as i32,
         Err(e) => {
-            log::error!("file_read: {:?}", e);
+            error!("file_read: {:?}", e);
             -1
         }
     };
@@ -75,7 +79,7 @@ unsafe extern "C" fn file_write(
     match ctx.offset_write(&write_buf, offset as u64) {
         Ok(len) => len as i32,
         Err(e) => {
-            log::error!("file_write: {:?}", e);
+            error!("file_write: {:?}", e);
             -1
         }
     }
@@ -87,7 +91,7 @@ unsafe extern "C" fn file_close(data: *mut c_void) -> i32 {
     match ctx.close() {
         Ok(_) => 0,
         Err(e) => {
-            log::error!("file_close: {:?}", e);
+            error!("file_close: {:?}", e);
             -1
         }
     }

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -145,6 +145,25 @@ pub enum OsdpError {
     Unknown,
 }
 
+#[cfg(feature = "defmt-03")]
+impl defmt::Format for OsdpError {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        match self {
+            OsdpError::PdInfo(e) => defmt::write!(f, "OsdpError::PdInfo({0})", e),
+            OsdpError::Command => defmt::write!(f, "OsdpError::Command"),
+            OsdpError::Event => defmt::write!(f, "OsdpError::Event"),
+            OsdpError::Query(e) => defmt::write!(f, "OsdpError::Query({0})", e),
+            OsdpError::FileTransfer(e) => defmt::write!(f, "OsdpError::FileTransfer({0})", e),
+            OsdpError::Setup => defmt::write!(f, "OsdpError::Setup"),
+            OsdpError::Parse(e) => defmt::write!(f, "OsdpError::Parse({0})", e.as_str()),
+            OsdpError::Channel(e) => defmt::write!(f, "OsdpError::Channel({0})", e),
+            OsdpError::PdInfoBuilder(e) => defmt::write!(f, "OsdpError::PdInfoBuilder({0})", e),
+            OsdpError::IO(_) => defmt::write!(f, "OsdpError::IO"), // Error cannot be formatted, because there is no way to set defmt::Format as a bound
+            OsdpError::Unknown => defmt::write!(f, "OsdpError::Unknown"),
+        }
+    }
+}
+
 impl From<core::convert::Infallible> for OsdpError {
     fn from(_: core::convert::Infallible) -> Self {
         unreachable!()

--- a/libosdp/src/pd.rs
+++ b/libosdp/src/pd.rs
@@ -15,6 +15,9 @@
 use crate::{OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo};
 use alloc::{boxed::Box, vec::Vec};
 use core::ffi::c_void;
+#[cfg(feature = "defmt-03")]
+use defmt::{debug, error, info, warn};
+#[cfg(not(feature = "defmt-03"))]
 use log::{debug, error, info, warn};
 
 type Result<T> = core::result::Result<T, OsdpError>;
@@ -30,14 +33,14 @@ unsafe extern "C" fn log_handler(
     let msg = crate::cstr_to_string(msg);
     let msg = msg.trim();
     match log_level as libosdp_sys::osdp_log_level_e {
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_EMERG => error!("PD: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_ALERT => error!("PD: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_CRIT => error!("PD: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_ERROR => error!("PD: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_WARNING => warn!("PD: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_NOTICE => warn!("PD: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_INFO => info!("PD: {msg}"),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_DEBUG => debug!("PD: {msg}"),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_EMERG => error!("PD: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_ALERT => error!("PD: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_CRIT => error!("PD: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_ERROR => error!("PD: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_WARNING => warn!("PD: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_NOTICE => warn!("PD: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_INFO => info!("PD: {}", msg),
+        libosdp_sys::osdp_log_level_e_OSDP_LOG_DEBUG => debug!("PD: {}", msg),
         _ => panic!("Unknown log level"),
     };
 }


### PR DESCRIPTION
`defmt` is quite common and very useful while debugging in embedded environment. This PR allows for libOSDP log messages to appear as standard `defmt` log messages and also to print common libOSDP structures with `defmt`.