### PR TITLE
Make sure cc and bindgen use the same size for enums

### DIFF
--- a/libosdp-sys/build.rs
+++ b/libosdp-sys/build.rs
@@ -162,11 +162,20 @@ fn main() -> Result<()> {
             .file("vendor/src/osdp_pcap.c");
     }
 
+    let short_enums = build.get_compiler().is_like_gnu() || build.get_compiler().is_like_clang();
+    if short_enums {
+        build.flag("-fshort-enums");
+    }
     build.compile("libosdp.a");
 
     /* generate bindings */
 
-    let args = vec![format!("-I{}", &out_dir)];
+    let mut args = vec![format!("-I{}", &out_dir)];
+    if short_enums {
+        args.push("-fshort-enums".to_owned());
+    } else {
+        args.push("-fno-short-enums".to_owned());
+    }
     let bindings = bindgen::Builder::default()
         .use_core()
         .header("vendor/include/osdp.h")


### PR DESCRIPTION
On my machine (Windows) `cc` (using `arm-none-eabi-gcc`) and `bindgen` (using `libclang`) did not agree on whether enums should be `i32` or not. This resulted in very broken code. This PR makes sure enums are always the same size for `cc` and `bindgen`.

Alternatively we could use `-fno-short-enums`, but I would prefer `-fshort-enums` because it will result in slightly less memory usage.