### PR TITLE
Optimize size for embedded devices

### DIFF
--- a/libosdp/Cargo.toml
+++ b/libosdp/Cargo.toml
@@ -16,10 +16,11 @@ categories = ["development-tools", "embedded"]
 bitflags = "2.4.0"
 embedded-io = { version = "0.6.1", features = ["alloc"] }
 libosdp-sys = { path = "../libosdp-sys", default-features = false }
-log = "0.4.20"
+log = { version = "0.4.20", optional = true }
 serde = { version = "1.0.192", features = ["derive", "alloc"], default-features = false }
 thiserror = { version = "1.0.50", optional = true }
 defmt = { version = "0.3", optional = true, features = ["alloc"] }
+itoa = "1.0.11"
 
 [dev-dependencies]
 env_logger = "0.11.3"
@@ -31,7 +32,8 @@ sha256 = "1.5.0"
 [features]
 default = ["std"]
 defmt-03 = ["embedded-io/defmt-03", "dep:defmt"]
-std = ["thiserror", "serde/std", "log/std"]
+log = ["dep:log"]
+std = ["thiserror", "serde/std", "log", "log/std"]
 
 [[example]]
 name = "cp"

--- a/libosdp/src/file.rs
+++ b/libosdp/src/file.rs
@@ -10,7 +10,7 @@ use alloc::{boxed::Box, vec};
 use core::ffi::c_void;
 #[cfg(feature = "defmt-03")]
 use defmt::error;
-#[cfg(not(feature = "defmt-03"))]
+#[cfg(all(feature = "log", not(feature = "defmt-03")))]
 use log::error;
 
 type Result<T> = core::result::Result<T, crate::OsdpError>;
@@ -44,8 +44,9 @@ unsafe extern "C" fn file_open(data: *mut c_void, file_id: i32, size: *mut i32) 
             }
             0
         }
-        Err(e) => {
-            error!("open: {:?}", e);
+        Err(_e) => {
+            #[cfg(any(feature = "log", feature = "defmt-03"))]
+            error!("open: {:?}", _e);
             -1
         }
     }
@@ -57,8 +58,9 @@ unsafe extern "C" fn file_read(data: *mut c_void, buf: *mut c_void, size: i32, o
     let mut read_buf = vec![0u8; size as usize];
     let len = match ctx.offset_read(&mut read_buf, offset as u64) {
         Ok(len) => len as i32,
-        Err(e) => {
-            error!("file_read: {:?}", e);
+        Err(_e) => {
+            #[cfg(any(feature = "log", feature = "defmt-03"))]
+            error!("file_read: {:?}", _e);
             -1
         }
     };
@@ -78,8 +80,9 @@ unsafe extern "C" fn file_write(
     core::ptr::copy_nonoverlapping(buf as *mut u8, write_buf.as_mut_ptr(), size as usize);
     match ctx.offset_write(&write_buf, offset as u64) {
         Ok(len) => len as i32,
-        Err(e) => {
-            error!("file_write: {:?}", e);
+        Err(_e) => {
+            #[cfg(any(feature = "log", feature = "defmt-03"))]
+            error!("file_write: {:?}", _e);
             -1
         }
     }
@@ -90,8 +93,9 @@ unsafe extern "C" fn file_close(data: *mut c_void) -> i32 {
     let ctx = ctx.as_mut().unwrap();
     match ctx.close() {
         Ok(_) => 0,
-        Err(e) => {
-            error!("file_close: {:?}", e);
+        Err(_e) => {
+            #[cfg(any(feature = "log", feature = "defmt-03"))]
+            error!("file_close: {:?}", _e);
             -1
         }
     }

--- a/libosdp/src/lib.rs
+++ b/libosdp/src/lib.rs
@@ -227,6 +227,7 @@ impl core::str::FromStr for OsdpFlag {
     }
 }
 
+#[allow(dead_code)]
 fn cstr_to_string(s: *const ::core::ffi::c_char) -> String {
     let s = unsafe { core::ffi::CStr::from_ptr(s) };
     s.to_str().unwrap().to_owned()

--- a/libosdp/src/pd.rs
+++ b/libosdp/src/pd.rs
@@ -13,13 +13,13 @@
 //! to the CP.
 
 use crate::{
-    Box, Channel, OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo,
-    PdInfoBuilder,
+    Channel, OsdpCommand, OsdpError, OsdpEvent, OsdpFileOps, PdCapability, PdInfo, PdInfoBuilder,
 };
+use alloc::{boxed::Box, vec::Vec};
 use core::ffi::c_void;
 #[cfg(feature = "defmt-03")]
 use defmt::{debug, error, info, warn};
-#[cfg(not(feature = "defmt-03"))]
+#[cfg(all(feature = "log", not(feature = "defmt-03")))]
 use log::{debug, error, info, warn};
 
 type Result<T> = core::result::Result<T, OsdpError>;
@@ -27,24 +27,27 @@ type CommandCallback =
     unsafe extern "C" fn(data: *mut c_void, event: *mut libosdp_sys::osdp_cmd) -> i32;
 
 unsafe extern "C" fn log_handler(
-    log_level: ::core::ffi::c_int,
+    _log_level: ::core::ffi::c_int,
     _file: *const ::core::ffi::c_char,
     _line: ::core::ffi::c_ulong,
-    msg: *const ::core::ffi::c_char,
+    _msg: *const ::core::ffi::c_char,
 ) {
-    let msg = crate::cstr_to_string(msg);
-    let msg = msg.trim();
-    match log_level as libosdp_sys::osdp_log_level_e {
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_EMERG => error!("PD: {}", msg),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_ALERT => error!("PD: {}", msg),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_CRIT => error!("PD: {}", msg),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_ERROR => error!("PD: {}", msg),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_WARNING => warn!("PD: {}", msg),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_NOTICE => warn!("PD: {}", msg),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_INFO => info!("PD: {}", msg),
-        libosdp_sys::osdp_log_level_e_OSDP_LOG_DEBUG => debug!("PD: {}", msg),
-        _ => panic!("Unknown log level"),
-    };
+    #[cfg(any(feature = "log", feature = "defmt-03"))]
+    {
+        let msg = crate::cstr_to_string(_msg);
+        let msg = msg.trim();
+        match _log_level as libosdp_sys::osdp_log_level_e {
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_EMERG => error!("PD: {}", msg),
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_ALERT => error!("PD: {}", msg),
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_CRIT => error!("PD: {}", msg),
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_ERROR => error!("PD: {}", msg),
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_WARNING => warn!("PD: {}", msg),
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_NOTICE => warn!("PD: {}", msg),
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_INFO => info!("PD: {}", msg),
+            libosdp_sys::osdp_log_level_e_OSDP_LOG_DEBUG => debug!("PD: {}", msg),
+            _ => panic!("Unknown log level"),
+        };
+    }
 }
 
 extern "C" fn trampoline<F>(data: *mut c_void, cmd: *mut libosdp_sys::osdp_cmd) -> i32


### PR DESCRIPTION
In an effort to reduce the size of release build on embedded devices this PR introduces the following changes:

- Use `itoa` instead of `format!` to convert an integer to a string, since `format!` contains a lot of bloat.
- `log` feature: Logging pulls in a lot of code and is often useless in embedded devices that don't have anything to log to. In this case it would be useful to be able to disable logging entirely.