### PR TITLE
Run CI job to ensure no-std compatibility

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -25,7 +25,13 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - run: cargo check
+          target: thumbv6m-none-eabi
+      - name: Cargo check
+        run: cargo check
+      - name: Install gcc-arm-none-eabi
+        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
+      - name: Cargo check no-std
+        run: cargo check --package libosdp --target thumbv6m-none-eabi --no-default-features
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR introduces a CI job to ensure that `libosdp` does not accidentally become incompatible with `no-std`. This will only work after goToMain/c-utils#28 (or similar) is merged.