### PR TITLE
Fix card data length for "raw bit array"

### DIFF
--- a/libosdp-sys/Cargo.toml
+++ b/libosdp-sys/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://libosdp.sidcha.dev/"
 readme = "README.md"
 repository = "https://github.com/goToMain/libosdp-rs"
 license = "Apache-2.0"
-keywords = ["osdp", "libosdp", "acs", "sia", "weigand"]
+keywords = ["osdp", "libosdp", "acs", "sia", "wiegand"]
 categories = ["development-tools", "embedded"]
 
 [build-dependencies]

--- a/libosdp/Cargo.toml
+++ b/libosdp/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://libosdp.sidcha.dev/"
 readme = "README.md"
 repository = "https://github.com/goToMain/libosdp-rs"
 license = "Apache-2.0"
-keywords = ["osdp", "libosdp", "acs", "sia", "weigand"]
+keywords = ["osdp", "libosdp", "acs", "sia", "wiegand"]
 categories = ["development-tools", "embedded"]
 
 [dependencies]

--- a/libosdp/src/events.rs
+++ b/libosdp/src/events.rs
@@ -27,7 +27,7 @@ pub enum OsdpCardFormats {
     /// Card format is not specified
     Unspecified,
 
-    /// Weigand format
+    /// Wiegand format
     Wiegand,
 
     /// Ascii format
@@ -87,7 +87,7 @@ pub struct OsdpEventCardRead {
     pub direction: bool,
 
     /// Number of valid data bits in [`OsdpEventCardRead::data`] when the card
-    /// format is [`OsdpCardFormats::Weigand`]. For all other formats, this
+    /// format is [`OsdpCardFormats::Wiegand`]. For all other formats, this
     /// field is set to zero.
     pub nr_bits: usize,
 
@@ -107,8 +107,8 @@ impl OsdpEventCardRead {
         }
     }
 
-    /// Create a Weigand card read event for self and direction set to forward
-    pub fn new_weigand(nr_bits: usize, data: Vec<u8>) -> Result<Self> {
+    /// Create a Wiegand card read event for self and direction set to forward
+    pub fn new_wiegand(nr_bits: usize, data: Vec<u8>) -> Result<Self> {
         if nr_bits > data.len() * 8 {
             return Err(OsdpError::Command);
         }
@@ -449,7 +449,7 @@ mod tests {
 
         assert_eq!(event, event_struct.into());
 
-        let event = OsdpEventCardRead::new_weigand(15, vec![0x55, 0xAA]).unwrap();
+        let event = OsdpEventCardRead::new_wiegand(15, vec![0x55, 0xAA]).unwrap();
         let event_struct: osdp_event_cardread = event.clone().into();
 
         assert_eq!(event_struct.length, 15);


### PR DESCRIPTION
Only formatted ASCII data is counted in bytes. All raw formats are counted in bits.

This also fixes all remaining `Weigand` typos I missed in #24.