### PR TITLE
feat(libosdp-sys): add ESP-IDF target support

### DIFF
--- a/libosdp-sys/build.rs
+++ b/libosdp-sys/build.rs
@@ -127,6 +127,15 @@ fn main() -> Result<()> {
     if target_os.is_empty() || target_os == "none" {
         println!("cargo:warning=Building for bare metal target");
         build = build.define("__BARE_METAL__", "1")
+    } else if target_os == "espidf" {
+        // ESP-IDF provides a POSIX-compatible environment (sys/time.h,
+        // gettimeofday, etc.).  The libosdp C code's __linux__ code path
+        // is compatible with ESP-IDF, so we reuse it here.
+        println!("cargo:warning=Building for ESP-IDF target (POSIX-compatible)");
+        build = build.define("__linux__", "1");
+        // ESP-IDF headers may trigger warnings that are not actionable
+        // when cross-compiling, so relax -Werror for this target.
+        build = build.warnings_into_errors(false);
     }
 
     let source_files = vec![


### PR DESCRIPTION
## Summary

Adds ESP-IDF (`target_os = "espidf"`) target support to `libosdp-sys/build.rs`.

ESP-IDF provides a POSIX-compatible environment (`sys/time.h`, `gettimeofday`, etc.), so the libosdp C code's `__linux__` code path works correctly on ESP-IDF. This patch:

- Detects `CARGO_CFG_TARGET_OS == "espidf"` and defines `__linux__` for the C build
- Relaxes `-Werror` for ESP-IDF targets, since ESP-IDF system headers may trigger warnings that are not actionable when cross-compiling

## Testing

Tested on **ESP32-S3** (Xtensa) with:
- ESP-IDF v5.3.3
- Rust ESP toolchain v1.93.0.0 (via espup)
- `libosdp` crate used from a Cargo workspace targeting `xtensa-esp32s3-espidf`

The firmware boots and runs OSDP communication successfully over RS-485.

## Context

Without this patch, building `libosdp-sys` for ESP-IDF targets fails because the C code falls through to a code path that lacks the POSIX time functions ESP-IDF provides. The `__linux__` define selects the correct POSIX-compatible code path.